### PR TITLE
Se arregla error al fallar la petición en `all`

### DIFF
--- a/lib/redmine_client/base.rb
+++ b/lib/redmine_client/base.rb
@@ -95,7 +95,7 @@ module RedmineClient
       def all
         headers['Content-Type'] = 'application/x-www-form-urlencoded'
         resource = get "#{resource_path}.json"
-        resource.ok? ? resource[plural_resource_name].map {|e| new(e)} : bad_response(resource, id)
+        resource.ok? ? resource[plural_resource_name].map {|e| new(e)} : bad_response(resource)
       end
     end
   end


### PR DESCRIPTION
Se intentaba acceder a una variable/método `id` no existente.